### PR TITLE
Fixed wrong BIOS for Critter Crusher

### DIFF
--- a/_ST-V/Critter Crusher (EA 951204 V1.000).mra
+++ b/_ST-V/Critter Crusher (EA 951204 V1.000).mra
@@ -8,7 +8,7 @@
 	</rom>
 	<rom index="2" md5="" zip="stvbios.zip" address="0x30000000">
 		<interleave output="64">
-			<part crc="d1be2adf" name="epr-17952a.ic8" map="21436587" />
+			<part crc="ff7722da3" name="epr-17954a.ic8" map="21436587" />
 		</interleave>
 	</rom>
 	<rom index="3" md5="" zip="critcrsh.zip" address="0x34000000">


### PR DESCRIPTION
To be able to run Critter Crusher, one needs to use the EU BIOS instead of the US one. Source: Saturn/ST-V compatibility spreadsheet. To actually play the game, one still needs a special controller. 