### PR TITLE
Fixed nested string runtime errors. Updated Readme documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ Generated MRA files for testing ST-V support in the MiSTer Saturn core.
 How to use:
 
 * Grab the latest release of this repo and extract it to /media/fat/_Arcade
-* Copy the latest Saturn core RBF to /media/fat/_Arcade/cores/Saturn.rbf
-* Copy all mame ST-V roms to /media/fat/games/mame. You will also need stvbios.zip. Merged sets are preferred, but split should also work.
+* Copy the latest Saturn core RBF to /media/fat/_Arcade/cores/ST-V.rbf
+* Copy stvbios.zip and all mame ST-V roms to /media/fat/games/mame. Merged sets are preferred, but split should also work.
 * All of the ST-V MRAs should be in ST-V directory in your Arcade list.
-* Launch any ST-V game. Open the OSD and change the 'Cart type' to STV. Save your settings.
-* Relaunch any ST-V MRA and it will now launch.
+* Launch any ST-V MRA.
 
 The ST-V support in the core is VERY work in progress. Many games will not boot, and some will boot but not allow you to start a game. 
 
@@ -16,5 +15,3 @@ ST-V Bios notes.
 
 These MRAs use the US bios by default. In the case where a game only supports JP bios, that one is used instead.
 Games that support both US and JP bios have a second MRA in the "JP Bios" directory that loads the JP one instead of the US one.
-
-

--- a/script/gen_mra.py
+++ b/script/gen_mra.py
@@ -124,9 +124,9 @@ def create_mra_tree(gameinfo, for_region="US"):
     add_buttons(mraroot, num_buttons)
     add_stv_mode(mraroot, gamename)
     zip_names = []
-    zip_names.append(f'{gameinfo.attrib['name']}.zip')
+    zip_names.append(f"{gameinfo.attrib['name']}.zip")
     if 'cloneof' in gameinfo.attrib:
-        zip_names.append(f'{gameinfo.attrib['cloneof']}.zip')
+        zip_names.append(f"{gameinfo.attrib['cloneof']}.zip")
     add_eeprom(mraroot, gamename=gameinfo.attrib['name'], zip_files=zip_names)
     add_bios(mraroot, region=for_region)
     rom_root = add_rom(mraroot, romindex="3", zipfiles=zip_names, address="0x34000000")
@@ -193,6 +193,10 @@ def create_mra_tree(gameinfo, for_region="US"):
     ET.indent(mratree, space="\t", level=0)
     return mratree
 
+def write_mra_tree(mra_tree, mra_filename):
+    with open(mra_filename, 'w', newline='\n') as f:
+        mra_tree.write(f, encoding='unicode')
+
 region_re = re.compile(r'.*\(([A-Z]+)\s+[0-9]')
 
 for gameinfo in hashroot.iter('software'):
@@ -205,16 +209,16 @@ for gameinfo in hashroot.iter('software'):
     mra_filename = mra_filename.replace(':', '-')
     
     if region_codes == 'J':
-        create_mra_tree(gameinfo, for_region="JP").write(mra_filename)
+        write_mra_tree(create_mra_tree(gameinfo, for_region="JP"), mra_filename)
     else:
         if 'U' in region_codes:
-            create_mra_tree(gameinfo, for_region="US").write(mra_filename)
+            write_mra_tree(create_mra_tree(gameinfo, for_region="US"), mra_filename)
         else:
-            create_mra_tree(gameinfo, for_region="EU").write(mra_filename)
+            write_mra_tree(create_mra_tree(gameinfo, for_region="EU"), mra_filename)
         if 'J' in region_codes:
             if not os.path.isdir("_JP Bios"):
                 os.makedirs("_JP Bios")
-            create_mra_tree(gameinfo, for_region="JP").write(os.path.join("_JP Bios", mra_filename))
+            write_mra_tree(create_mra_tree(gameinfo, for_region="JP"), os.path.join("_JP Bios", mra_filename))
 
 
 


### PR DESCRIPTION
Fixed nested string inside formatting using identical quotation characters causing runtime errors on my Windows system.

Updated the readme to reflect the core name change, and removed the part about changing the cart type to STV as it is no longer necessary,